### PR TITLE
Feature: 优化 Bot 连接与断开时机

### DIFF
--- a/nonebot/adapters/console/adapter.py
+++ b/nonebot/adapters/console/adapter.py
@@ -53,10 +53,8 @@ class Adapter(BaseAdapter):
         )
         self._frontend.backend.set_adapter(self)
         self._task = asyncio.create_task(self._frontend.run_async())
-        self.bot_connect(self.bot)
 
     async def _shutdown(self) -> None:
-        self.bot_disconnect(self.bot)
         if self._frontend:
             self._frontend.exit()
         if self._task:

--- a/nonebot/adapters/console/backend.py
+++ b/nonebot/adapters/console/backend.py
@@ -46,7 +46,8 @@ class AdapterConsoleBackend(Backend):
         )
 
     def on_console_mount(self):
-        pass
+        self._adapter.bot_connect(self._adapter.bot)
+        logger.success("Console mounted.")
 
     def on_console_unmount(self):
         if self._logger_id is not None:
@@ -61,7 +62,8 @@ class AdapterConsoleBackend(Backend):
                 format=default_format,
             )
             self._should_restore_logger = False
-        logger.success("Console exit.")
+        self._adapter.bot_disconnect(self._adapter.bot)
+        logger.success("Console unmounted.")
         logger.warning("Press Ctrl-C for Application exit")
 
     async def post_event(self, event: ConsoleEvent):


### PR DESCRIPTION
目前 adapter-console 上报 Bot 断开的时机需要在终端断开且按下 Ctrl-C 之后，这将导致终端断开以后，彻底终止程序之前，与定时任务相关的所有行为无法被暂停。因此，本提交将上报 Bot 断开的时机前移到了终端断开时刻 (on_console_unmount)，同时为了对称，把上报 Bot 连接的时机推迟到了终端挂载时刻 (on_console_mount)。该提交将能使 Driver.bot_disconnect 装饰器生效，从而使得定时任务能够提前关闭。

从日志分析而言，会将程序流程从：
```
[INFO] uvicorn | Application startup complete.
[INFO] uvicorn | Uvicorn running on xxxxx (Press CTRL+C to quit)
[WARNING] nonebot | Press Ctrl-C for Application exit
[INFO] uvicorn | Shutting down
[INFO] uvicorn | Waiting for application shutdown.
[INFO] nonebot_plugin_apscheduler | Scheduler Shutdown
[DEBUG] nonebot | Waiting for running bot connection hooks...
[INFO] uvicorn | Application shutdown complete.
```
变为：
```
[INFO] uvicorn | Application startup complete.
[INFO] uvicorn | Uvicorn running on xxxxx (Press CTRL+C to quit)
[SUCCESS] nonebot | Console mounted.
[SUCCESS] nonebot | Console unmounted.
[WARNING] nonebot | Press Ctrl-C for Application exit
[INFO] uvicorn | Shutting down
[INFO] uvicorn | Waiting for application shutdown.
[INFO] nonebot_plugin_apscheduler | Scheduler Shutdown
[INFO] uvicorn | Application shutdown complete.
```