### PR TITLE
Rename API method 'get_channels' to 'list_channels'

### DIFF
--- a/nonebot/adapters/console/adapter.py
+++ b/nonebot/adapters/console/adapter.py
@@ -84,7 +84,7 @@ class Adapter(BaseAdapter):
             return await self._frontend.backend.get_channel(data["channel_id"])
         if api == "get_users":
             return await self._frontend.backend.list_users()
-        if api == "get_channels":
+        if api == "list_channels":
             return await self._frontend.backend.list_channels(data.get("list_users", False))
         if api == "create_dm":
             user = await self._frontend.backend.get_user(data["user_id"])


### PR DESCRIPTION
在0.8.0的更新中，get_channels方法更名为list_channels方法，请求的api为“list_channels”，而此处api没有更改

这是我第一次做pr，不太熟悉流程，如果有建议希望能够指出，谢谢！